### PR TITLE
Avoid polling the Connection thread.

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -155,7 +155,7 @@ class Connection(Thread):
                 self._loop.call_soon_threadsafe(future.set_result, result)
             except BaseException as e:
                 LOG.exception("returning exception %s", e)
-                self._loop.call_soon_threadsafe(future.set_exception(e))
+                self._loop.call_soon_threadsafe(future.set_exception, e)
 
     async def _execute(self, fn, *args, **kwargs):
         """Queue a function with the given arguments for execution."""


### PR DESCRIPTION
### Description

Rather than poll the sqlite thread in the `Connection` class, `asyncio.Future`s can be directly used along with `call_soon_threadsafe`. This means less time is spent blocking the reactor loop. Additionally, the lock in `execute()` can be removed, allowing tasks to be queued.

Fixes: #14.
