### PR TITLE
Implement sqlite3 extension shims

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -274,6 +274,12 @@ class Connection(Thread):
     def total_changes(self) -> int:
         return self._conn.total_changes
 
+    async def enable_load_extension(self, value: bool) -> None:
+        await self._execute(self._conn.enable_load_extension, value)  # type: ignore
+
+    async def load_extension(self, path: str):
+        await self._execute(self._conn.load_extension, path)  # type: ignore
+
 
 def connect(
     database: Union[str, Path], *, loop: asyncio.AbstractEventLoop = None, **kwargs: Any

--- a/tests/smoke.py
+++ b/tests/smoke.py
@@ -195,19 +195,6 @@ class SmokeTest(aiounittest.AsyncTestCase):
             rows = await cursor.fetchall()
             self.assertEqual(rows, [(10,), (24,), (16,)])
 
-    async def test_load_extension(self):
-        """Assert that loading an extension without enabling raises 'not authorized'"""
-        async with aiosqlite.connect(TEST_DB) as db:
-            try:
-                await db.load_extension("test")
-            except OperationalError as e:
-                assert "not authorized" in e.args
-            except AttributeError:
-                raise SkipTest(
-                    "python was not compiled with sqlite3 "
-                    "extension support, so we can't test it"
-                )
-
     async def test_enable_load_extension(self):
         """Assert that after enabling extension loading, they can be loaded"""
         async with aiosqlite.connect(TEST_DB) as db:


### PR DESCRIPTION
### Description

So that's the easy part done. One problem though is that not all distributions of python (and by extension, sqlite3) are compiled with extension loading included. This causes a few things to happen:

- disable mypy for the 2 lines that reference the "missing" functions since they aren't in typeshed
- raise SkipTest if python is compiled without sqlite3 extension support

If you try and call `enable_load_extension` or `load_extension` when python is not compiled with sqlite extensions enabled, it will just raise an attribute error because the functions do not exist. I didn't handle the error so that functionality is the same in `aiosqlite` as `sqlite3` but maybe it would be an idea to provide a more descriptive error?

Fixes: #22 
