### PR TITLE
Enable 3.8 builds in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,5 @@
 name: Build
-on: 
+on:
   push:
     branches:
       - master
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7]
+        python-version: [3.5, 3.6, 3.7, 3.8]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
### Description

Adds Python 3.8 builds to CI 

Fixes: #50
