### PR TITLE
Enable use of custom functions

### DIFF
--- a/aiosqlite/core.py
+++ b/aiosqlite/core.py
@@ -245,6 +245,13 @@ class Connection(Thread):
         """Interrupt pending queries."""
         return self._conn.interrupt()
 
+    async def create_function(self, name: str, num_params: int, func: Callable) -> None:
+        """Create user-defined function that can be later used
+        within SQL statements. Must be run within the same thread
+        that query executions take place so instead of executing directly
+        against the connection, we defer this to `run` function."""
+        await self._execute(self._conn.create_function, name, num_params, func)
+
     @property
     def in_transaction(self) -> bool:
         return self._conn.in_transaction

--- a/aiosqlite/tests/smoke.py
+++ b/aiosqlite/tests/smoke.py
@@ -233,3 +233,24 @@ class SmokeTest(aiounittest.AsyncTestCase):
                 await db.execute(
                     "create table test_progress_handler (i integer primary key asc, k integer)"
                 )
+
+    async def test_create_function(self):
+        """Assert that after creating a custom function, it can be used"""
+
+        def no_arg():
+            return "no arg"
+
+        def one_arg(num):
+            return num * 2
+
+        async with aiosqlite.connect(TEST_DB) as db:
+            await db.create_function("no_arg", 0, no_arg)
+            await db.create_function("one_arg", 1, one_arg)
+
+            async with db.execute("SELECT no_arg();") as res:
+                row = await res.fetchone()
+                self.assertEqual(row[0], "no arg")
+
+            async with db.execute("SELECT one_arg(10);") as res:
+                row = await res.fetchone()
+                self.assertEqual(row[0], 20)


### PR DESCRIPTION
### Description

This change allows users to use the `create_function` method of `sqlite`. Currently it was not working because users were accessing the underlying `sqlite3.Connection` object and running this method against it. The issue is that all the other query methods are running in another thread and `sqlite` does not allow you to share the created object amongst threads. Now the created function statement gets executed in the same thread as queries allowing this functionality to work as intended.

Fixes: #54 
